### PR TITLE
Add basic Flask webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,27 @@ Simple currency convertor that gets, rates from public API (https://app.exchange
 Get custom API key form exchangerate.com, after paste in code as shown.
 
 ![alt text](image-1.png)
+
+## Web Application
+
+A simple Flask web application is included in `webapp/`. It provides:
+
+- **Landing Page** (`/`)
+- **Currency Conversion Page** (`/convert`)
+- **Graph Page** (`/graph`)
+
+### Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r webapp/requirements.txt
+```
+
+2. Run the application:
+
+```bash
+python webapp/app.py
+```
+
+The application will start on `http://127.0.0.1:5000/`.

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,60 @@
+from flask import Flask, render_template, request
+import requests
+from datetime import datetime, timedelta
+
+app = Flask(__name__)
+
+API_URL = "https://api.exchangerate.host"
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/convert', methods=['GET', 'POST'])
+def convert():
+    result = None
+    if request.method == 'POST':
+        amount = request.form.get('amount', type=float, default=0.0)
+        from_currency = request.form.get('from_currency', 'USD')
+        to_currency = request.form.get('to_currency', 'EUR')
+        try:
+            resp = requests.get(f"{API_URL}/convert", params={
+                'from': from_currency,
+                'to': to_currency,
+                'amount': amount
+            })
+            resp.raise_for_status()
+            data = resp.json()
+            result = data.get('result')
+        except Exception as exc:
+            result = f"Error: {exc}"
+    return render_template('convert.html', result=result)
+
+@app.route('/graph', methods=['GET', 'POST'])
+def graph():
+    rates = []
+    labels = []
+    if request.method == 'POST':
+        base = request.form.get('base', 'USD')
+        target = request.form.get('target', 'EUR')
+        end_date = datetime.today()
+        start_date = end_date - timedelta(days=6)
+        try:
+            resp = requests.get(f"{API_URL}/timeseries", params={
+                'start_date': start_date.strftime('%Y-%m-%d'),
+                'end_date': end_date.strftime('%Y-%m-%d'),
+                'base': base,
+                'symbols': target
+            })
+            resp.raise_for_status()
+            data = resp.json()
+            for date, rate in sorted(data.get('rates', {}).items()):
+                labels.append(date)
+                rates.append(rate.get(target))
+        except Exception as exc:
+            labels.append('Error')
+            rates.append(0)
+    return render_template('graph.html', labels=labels, rates=rates)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/webapp/templates/convert.html
+++ b/webapp/templates/convert.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Convert</title>
+</head>
+<body>
+    <h1>Currency Converter</h1>
+    <form method="post">
+        <label>Amount: <input type="number" step="any" name="amount"></label><br>
+        <label>From: <input name="from_currency" value="USD"></label><br>
+        <label>To: <input name="to_currency" value="EUR"></label><br>
+        <button type="submit">Convert</button>
+    </form>
+    {% if result %}
+    <p>Result: {{ result }}</p>
+    {% endif %}
+    <p><a href="/">Back</a></p>
+</body>
+</html>

--- a/webapp/templates/graph.html
+++ b/webapp/templates/graph.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Exchange Graph</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <h1>Exchange Rate Graph</h1>
+    <form method="post">
+        <label>Base: <input name="base" value="USD"></label><br>
+        <label>Target: <input name="target" value="EUR"></label><br>
+        <button type="submit">Show</button>
+    </form>
+    <canvas id="chart" width="400" height="200"></canvas>
+    <script>
+    const labels = {{ labels|tojson }};
+    const data = {{ rates|tojson }};
+    if(labels.length > 0){
+        new Chart(document.getElementById('chart').getContext('2d'), {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [{ label: 'Rate', data: data, fill: false, borderColor: 'rgb(75, 192, 192)' }]
+            }
+        });
+    }
+    </script>
+    <p><a href="/">Back</a></p>
+</body>
+</html>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Currency Converter</title>
+</head>
+<body>
+    <h1>Welcome to Currency Converter</h1>
+    <nav>
+        <ul>
+            <li><a href="/convert">Convert Currency</a></li>
+            <li><a href="/graph">View Exchange Graph</a></li>
+        </ul>
+    </nav>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask based webapp
- implement landing, conversion and graph pages
- document how to run the webapp

## Testing
- `python -m py_compile webapp/app.py`

------
https://chatgpt.com/codex/tasks/task_b_684099a2fe20832583b397709ef7241c